### PR TITLE
It turns out, in some cases, the span may not be available.

### DIFF
--- a/lib/console/output/datadog/wrapper.rb
+++ b/lib/console/output/datadog/wrapper.rb
@@ -38,12 +38,16 @@ module Console
 				
 				def call(subject = nil, *arguments, **options, &block)
 					if trace = ::Datadog::Tracing.active_trace
-						span = trace.active_span
-					
-						options[:dd] = {
-							span_id: span.id.to_s,
-							trace_id: trace.id.to_s
-						}
+						if span = trace.active_span
+							options[:dd] = {
+								span_id: span.id.to_s,
+								trace_id: trace.id.to_s
+							}
+						else
+							options[:dd] = {
+								trace_id: trace.id.to_s
+							}
+						end
 					end
 					
 					@output.call(subject, *arguments, **options, &block)

--- a/test/console/output/datadog.rb
+++ b/test/console/output/datadog.rb
@@ -37,5 +37,20 @@ describe Console::Output::Datadog do
 				logger.info("Hello World")
 			end
 		end
+		
+		it "should log message with datadog correlation even if span is missing" do
+			Datadog::Tracing.trace("frobulate.apply",service: "frobulate") do |span, trace|
+				expect(trace).to receive(:active_span).and_return(nil)
+				
+				expect(buffer).to receive(:call).with("Hello World",
+					severity: :info,
+					dd: {
+						trace_id: span.trace_id.to_s
+					}
+				)
+				
+				logger.info("Hello World")
+			end
+		end
 	end
 end


### PR DESCRIPTION
It looks like there might be a bug in `ddtrace` where traces are per-thread and spans are per-fiber. When using async, `active_span` might be `nil` even if there is a valid trace.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
