### PR TITLE
Use 64-bit trace_ids as required by the current implementation of Datadog.

### DIFF
--- a/lib/console/output/datadog/wrapper.rb
+++ b/lib/console/output/datadog/wrapper.rb
@@ -27,6 +27,8 @@ require 'ddtrace'
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# frozen_string_literal: true
+
 module Console
 	module Output
 		# The reason why this is a serialized logger rather than an output filter, is because it needs to directly modify the top level of the record.
@@ -41,16 +43,23 @@ module Console
 						if span = trace.active_span
 							options[:dd] = {
 								span_id: span.id.to_s,
-								trace_id: trace.id.to_s
+								trace_id: format_trace_id(trace.id)
 							}
 						else
 							options[:dd] = {
-								trace_id: trace.id.to_s
+								trace_id: format_trace_id(trace.id)
 							}
 						end
 					end
 					
 					@output.call(subject, *arguments, **options, &block)
+				end
+				
+				private
+				
+				def format_trace_id(id)
+					# 128-bit tracing is not supported by the Datadog agent, so we need to convert it to 64-bit. We expect that this will be changed in the future.
+					::Datadog::Tracing::Utils::TraceId.to_low_order(id)
 				end
 			end
 		end

--- a/test/console/output/datadog.rb
+++ b/test/console/output/datadog.rb
@@ -29,7 +29,7 @@ describe Console::Output::Datadog do
 				expect(buffer).to receive(:call).with("Hello World",
 					severity: :info,
 					dd: {
-						trace_id: span.trace_id.to_s,
+						trace_id: ::Datadog::Tracing::Correlation::Identifier.new(trace_id: span.trace_id).trace_id,
 						span_id: span.id.to_s
 					}
 				)
@@ -45,7 +45,7 @@ describe Console::Output::Datadog do
 				expect(buffer).to receive(:call).with("Hello World",
 					severity: :info,
 					dd: {
-						trace_id: span.trace_id.to_s
+						trace_id: ::Datadog::Tracing::Correlation::Identifier.new(trace_id: span.trace_id).trace_id
 					}
 				)
 				


### PR DESCRIPTION
See <https://github.com/DataDog/dd-trace-rb/pull/3447> for more context.

I've added tests that will hopefully break if any of the assumptions made no longer hold true.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
